### PR TITLE
ft(ch1-sign-in): accessing entries in UI

### DIFF
--- a/UI/html/sign-in.html
+++ b/UI/html/sign-in.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <link rel="stylesheet" href="../css/styles.css">
+  <title>My Diary | Sign in</title>
+</head>
+
+<body>
+  <header class="header">
+    <div class="container">
+      <nav class="nav">
+        <a href="./index.html" class="logo">My Diary</a>
+        <button class="button menu-button primary-button">
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+        <nav class="menu4mobile hidden">
+          <button class="button primary-button close-menu">&times;</button>
+          <ul class="nav-menu">
+            <li class="menu-item">
+              <a href="./sign-up.html" class="button primary-button">Sign up</a>
+            </li>
+          </ul>
+        </nav>
+        <ul class="nav-menu">
+          <li class="menu-item">
+            <a href="./sign-up.html" class="button primary-button small-button">Sign up</a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="main container">
+    <section class="form-container">
+      <div class="form">
+        <p class="form-header">Sign in with your My Diary account.</p>
+        <form action="./user-dashboard.html" class="signin-form">
+          <div class="form-style">
+            <input type="email" class="form-input" pattern="[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{3,}$" placeholder="Email"
+              required>
+          </div>
+          <div class="form-style">
+            <input type="password" class="form-input" placeholder="Password" required>
+          </div>
+          <div class="form-style">
+            <button type="submit" class="button primary-button">Sign in</a></button>
+          </div>
+          <span>If you don't have an account at My Diary
+            <a href="./sign-up.html">Sign Up</a>
+          </span>
+        </form>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p> <span>My Diary</span> &#9400; 2019, Emmanuel Nkurunziza </p>
+  </footer>
+  <script src="../js/index.js"></script>
+</body>
+
+</html>


### PR DESCRIPTION
#### What does this PR do?
 - adds a sign in form
 - adds a button to submit details


#### Description of Task to be completed
 - A user should be able to sign in using a form and on clicking the submit button, they are redirected to the user-dashboard page

#### How should this be manually tested?
- clone the repo and switch to the branch ft-ch1-sign-in-169109278
- use the url ` https://emmanuel-nkurunziza.github.io/My_Diary/UI/html/sign-in.html ` to open the sign-in page
- enter details in field and click signup
- you should be successfully redirected to user-dashboard.html

#### Any background context you want to provide?
- N/A

#### What are the relevant pivotal tracker stories?
[#169109278]( https://www.pivotaltracker.com/story/show/169109278)

#### Screenshots (if appropriate)
Image of sign-in page
![image](https://user-images.githubusercontent.com/52543344/66716002-eb18ef00-edc9-11e9-9b21-8bf30698201b.png)
