### PR TITLE
ft(ch1- number-entries): showing the number of entries in UI

### DIFF
--- a/UI/html/user-settings.html
+++ b/UI/html/user-settings.html
@@ -61,7 +61,9 @@
       <div class="profile-setting">
         <span>Notification Setting:</span> <input type="checkbox">
       </div>
-
+      <div class="profile-setting">
+        <span>Total Dairy Entries: 3</span>
+      </div>
     </section>
   </main>
 


### PR DESCRIPTION
#### What does this PR do?
 - adds a table of user profile contents
 - adds in the profile content a field of a number of dairy entries since the creation of account

#### Description of Task to be completed
 - A user should be able to take see a number of dairy entries since the creation of account

#### How should this be manually tested?
- clone the repo and switch to the branch ft-ch1-number-entries-169109468 
- use the url ` https://emmanuel-nkurunziza.github.io/My_Diary/UI/html/user-settings.html ` to open the user-settings page 
- you should be able to see, in the profile, the field with the number of entries since registration

#### Any background context you want to provide? 
- N/A

#### What are the relevant pivotal tracker stories?
[#169109468]( https://www.pivotaltracker.com/story/show/169109468)

#### Screenshots (if appropriate)
Image of the user-settings page
![image](https://user-images.githubusercontent.com/52543344/66720889-39e27b00-ee02-11e9-999d-6d3ef8ad890a.png)
