### PR TITLE
[ #169363080] ft(ch1-correction-in-UI): Some correction in UI

### DIFF
--- a/UI/CSS/styles.css
+++ b/UI/CSS/styles.css
@@ -399,7 +399,7 @@ img {
   color: #000000;
   text-align: center;
   border-radius: 10px;
-  border-bottom: 3px solid #ffffff;
+  border-bottom: 3px solid rgb(0,0,0,0.3);
 }
 
 .story-box-content {

--- a/UI/html/add-entry.html
+++ b/UI/html/add-entry.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="../CSS/styles.css">
   <title>My Diary | Add entry</title>
 </head>
 

--- a/UI/html/index.html
+++ b/UI/html/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="../CSS/styles.css">
   <title>MyDiary | index</title>
 </head>
 

--- a/UI/html/modify-entry.html
+++ b/UI/html/modify-entry.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="../CSS/styles.css">
   <title>My Diary | Modify entry</title>
 </head>
 

--- a/UI/html/sign-in.html
+++ b/UI/html/sign-in.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="../CSS/styles.css">
   <title>My Diary | Sign in</title>
 </head>
 

--- a/UI/html/sign-up.html
+++ b/UI/html/sign-up.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="../CSS/styles.css">
   <title>My Diary | Sign up</title>
 </head>
 

--- a/UI/html/user-dashboard.html
+++ b/UI/html/user-dashboard.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="../CSS/styles.css">
   <title>My Diary | Dashboard</title>
 </head>
 

--- a/UI/html/user-settings.html
+++ b/UI/html/user-settings.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="../CSS/styles.css">
   <title>Profile - My Diary</title>
 </head>
 

--- a/UI/html/view-entry.html
+++ b/UI/html/view-entry.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="stylesheet" href="../CSS/styles.css">
     <title>My Diary | View entry</title>
 </head>
 
@@ -117,7 +117,7 @@
     <footer class="footer">
         <p> <span>My Diary</span> &#9400; 2019, Emmanuel Nkurunziza </p>
     </footer>
-    <script src="./js/index.js"></script>
+    <script src="../js/index.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
#### What does this PR do?
this bug makes the following adjustments in UI:
- CSS folder made capital letters in HTML codes for all pages
- Black line separating the Titles and stories in user-dashboard page
- The view-entry.html page made connected to the ../js/index.js to make the mobile menu appear

#### Description of Task to be completed
- as  a User when navigates to all the pages; they should be styled. For that to be possible it is important that the folder CSS named in capital letter, the same name should be in the html codes
- as a User I navigate to the user-dashboard page, I should be able to differentiate clearly title and brief story 
- as a User I navigate to the view-entry page, I should be able to click the hamburger button for the small screen and have the mobile –menu coming

#### How should this be manually tested?
- clone the repo and switch to the branch bg-ch1-correction-in-UI-169363080
- use the url `https://github.com/Emmanuel-Nkurunziza/My_Diary/UI/html/index.html`
- use the url `https://github.com/Emmanuel-Nkurunziza/My_Diary/UI/htm/user-dashboard.html`
use the url `https://github.com/Emmanuel-Nkurunziza/My_Diary/UI/html/view-entry.html`
- you should be successfully redirected to home.html

#### Any background context you want to provide?
- N/A

#### What are the relevant pivotal tracker stories?
[#169363080](https://www.pivotaltracker.com/story/show/169363080)

#### Screenshots (if appropriate) 
Image of the user-dashboard page
![image](https://user-images.githubusercontent.com/52543344/67570708-58197680-f732-11e9-85ae-5e2b53b8e171.png)

Image of the view-entry mobile menu
![image](https://user-images.githubusercontent.com/52543344/67570828-a464b680-f732-11e9-81f1-d3cff7e9def5.png)
 