### PR TITLE
[#169377834] ft(ch2-add-entry): Add Entry API

### DIFF
--- a/server/controllers/entryControllers.js
+++ b/server/controllers/entryControllers.js
@@ -1,0 +1,27 @@
+import { Entry } from '../models/entry';
+import { emailDecrypt } from '../helpers/helpers4entry';
+import entryTimeStamp from '../helpers/entryCreationTime';
+
+
+const entries = [];
+
+
+class Controller4entry {
+  static createEntry = (req, res) => {
+    let {
+      title, description,
+    } = req.body;
+    const authEmail = emailDecrypt(req.header('authorization'));
+    const date = entryTimeStamp();
+    const entry = new Entry(entries.length + 1, title, date, description, authEmail);
+    entries.push(entry);
+    // console.log(entry);
+    return res.status(200).send({
+      status: 200,
+      message: 'Entry created successfully',
+      data: entry,
+    });
+  }
+}
+
+export default Controller4entry;

--- a/server/helpers/entryCreationTime.js
+++ b/server/helpers/entryCreationTime.js
@@ -1,0 +1,9 @@
+const entryTimeStamp = () => {
+  const today = new Date();
+  const date = `${today.getFullYear()}-${today.getMonth() + 1}-${today.getDate()}`;
+  const time = `${today.getHours()}:${today.getMinutes()}:${today.getSeconds()}`;
+  const precisedTime = `${date} ${time}`;
+  return precisedTime;
+};
+
+export default entryTimeStamp;

--- a/server/middleware/entryValidation.middleware.js
+++ b/server/middleware/entryValidation.middleware.js
@@ -1,0 +1,22 @@
+import Joi from 'joi';
+
+const createEntrySchema = (req, res, next) => {
+  const entryDetails = {
+    title: Joi.string().strict().trim().min(3)
+      .required(),
+    description: Joi.string().strict().trim().min(3)
+      .required(),
+
+  };
+  const result = Joi.validate(req.body, entryDetails);
+  if (result.error) {
+    return res.status(400).send({
+      status: 400,
+      error: `${result.error.details[0].message}`,
+    });
+  }
+
+  next();
+};
+
+export default createEntrySchema;

--- a/server/models/entries4test.js
+++ b/server/models/entries4test.js
@@ -1,0 +1,31 @@
+
+export const entries = [
+
+  // for edit entry
+  // data 0 test creating entry
+  {
+    title: '',
+    description: 'Tomorrow is going to be a public holiday and I have finished all the work that I am supposed to do today!',
+  },
+  // data 1 test lastName required
+  {
+    title: 'Happy and excited!',
+    description: '',
+  },
+  // data 2 test email required
+  {
+    title: 'Happy and excited!',
+    description: 'Tomorrow is going to be a public holiday and I have finished all the work that I am supposed to do today!',
+  },
+  // valid 3 data test signup successful and if email has been used
+  {
+    title: '',
+    description: '',
+  },
+  // valid 4 data test signin email required
+  {
+    title: 'I am happy that my lover said yes!',
+    description: 'Tomorrow is going to be a public holiday and I have finished all the work that I am supposed to do today!',
+  },
+
+];

--- a/server/models/entry.js
+++ b/server/models/entry.js
@@ -1,0 +1,9 @@
+export class Entry {
+  constructor(entryId, entryTitle, entryDate, entryDescription, userEmail) {
+    this.id = entryId;
+    this.title = entryTitle;
+    this.date = entryDate;
+    this.description = entryDescription;
+    this.userEmail = userEmail;
+  }
+}

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,13 +1,16 @@
 import express from 'express';
 import signUpSchema from '../middleware/userValidation.middleware';
 import Controller4user from '../controllers/userControllers';
-
+import Controller4entry from '../controllers/entryControllers';
+import createEntrySchema from '../middleware/entryValidation.middleware';
+import authanticate from '../middleware/userAuth.middleware';
 
 const router = express.Router();
 
 
 router.post('/auth/signup', signUpSchema, Controller4user.signUp);
 router.post('/auth/signin', Controller4user.signIn);
+router.post('/entries', authanticate, createEntrySchema, Controller4entry.createEntry);
 
 
 export default router;

--- a/server/tests/ytests4entry.js
+++ b/server/tests/ytests4entry.js
@@ -1,0 +1,137 @@
+import jwt from 'jsonwebtoken';
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import dotenv from 'dotenv';
+import { entries } from '../models/entries4test';
+import server from '../server';
+
+dotenv.config();
+const { expect } = chai;
+chai.use(chaiHttp);
+
+
+// test entries
+
+
+let userToken;
+const token = '';
+let wrongToken;
+let nonExistToken = jwt.sign({
+  userEmail: 'emmanuelNkurunziza@gmail.com',
+}, process.env.secretOrPrivateKey);
+const invalidToken = 'this is not the structure of a token';
+// Add Entry
+describe('POST entries ,/api/v1/entries', () => {
+  beforeEach((done) => {
+    chai.request(server).post('/api/v1/auth/signin').send({
+      email: 'emmanuel@gmail.com',
+      password: 'nkurunziza123',
+    }).then((res) => {
+      userToken = res.body.data.token;
+      done();
+    })
+      .catch((err) => console.log(err));
+  });
+  it('should return "title" is required ', (done) => {
+    chai.request(server)
+      .post('/api/v1/entries')
+      .set('authorization', userToken)
+      .set('Accept', 'application/json')
+      .send(entries[0])
+      .then((res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(400);
+        expect(res.body.status).to.equal(400);
+        expect(res.body.error).to.equal('"title" is not allowed to be empty');
+        done();
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  });
+  it('should return: description is not allowed to be empty', (done) => {
+    chai.request(server)
+      .post('/api/v1/entries')
+      .set('authorization', userToken)
+      .set('Accept', 'application/json')
+      .send(entries[1])
+      .then((res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(400);
+        expect(res.body.status).to.equal(400);
+        expect(res.body.error).to.equal('"description" is not allowed to be empty');
+        done();
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  });
+  it('should return: "You haven\'t provide your token"', (done) => {
+    chai.request(server)
+      .post('/api/v1/entries')
+      .set('authorization', token)
+      .set('Accept', 'application/json')
+      .send(entries[2])
+      .then((res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(400);
+        expect(res.body.status).to.equal(400);
+        expect(res.body.error).to.equal('there is no token provided!');
+        done();
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  });
+  it('should return You are not authorized to perform this action', (done) => {
+    chai.request(server)
+      .post('/api/v1/entries')
+      .set('authorization', nonExistToken)
+      .set('Accept', 'application/json')
+      .send(entries[2])
+      .then((res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(401);
+        expect(res.body.status).to.equal(401);
+        expect(res.body.error).to.equal('You are not registered in my Diary!');
+        done();
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  });
+  it('should return jwt malformed', (done) => {
+    chai.request(server)
+      .post('/api/v1/entries')
+      .set('authorization', invalidToken)
+      .set('Accept', 'application/json')
+      .send(entries[2])
+      .then((res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(400);
+        expect(res.body.status).to.equal(400);
+        done();
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  });
+
+  it('should return entry successfully created', (done) => {
+    chai.request(server)
+      .post('/api/v1/entries')
+      .set('authorization', userToken)
+      .set('Accept', 'application/json')
+      .send(entries[2])
+      .then((res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(200);
+        expect(res.body.status).to.equal(200);
+        expect(res.body.message).to.equal('Entry created successfully');
+        done();
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do? 
 with this feature, the user should be able to:
1.use the provided token,
2.have an authorization token allowing user to write a diary entry title and description


#### Description of Task to be completed
-  with this feature we put to place to the following functionalities to build the add entry API:
1.make the create entry method of the controller entry
2.the entry time stamp function in the helper
3.email decryption function helper to reference entries
4.create Entry Schema middleware function
5.create entry model
6.create entry model for test


#### How should this be manually tested?
- clone the repo and switch to the branch ft-ch2-add-entry-169377834
- start the server
-  with this feature the following has been done to test the signup API functionalities:
1.run the test of the codes of add entry
3.also testing the add entry API functionalities in POSTMAN

#### Any background context you want to provide?
- N/A

#### What are the relevant pivotal tracker stories?
[#169377834](https://www.pivotaltracker.com/story/show/169377834)

#### Screenshots (if appropriate)
Image of the Add Entry API tested in POSTMAN
![image](https://user-images.githubusercontent.com/52543344/67612518-9a2ed080-f7a3-11e9-8e39-8e831c81a578.png)
