### PR TITLE
[#169378224] ft(ch2-modify-entry): Modify Entry API

### DIFF
--- a/server/controllers/entryControllers.js
+++ b/server/controllers/entryControllers.js
@@ -7,6 +7,7 @@ const entries = [];
 
 
 class Controller4entry {
+  // Add Entry
   static createEntry = (req, res) => {
     let {
       title, description,
@@ -20,6 +21,44 @@ class Controller4entry {
       status: 200,
       message: 'Entry created successfully',
       data: entry,
+    });
+  }
+
+  // Modify Entry 
+  static editEntry = (req, res) => {
+    let {
+      title, description,
+    } = req.body;
+    let { entryId } = req.params;
+    if (isNaN(entryId)) {
+      return res.status(400).send({
+        status: 400,
+        error: 'The entry id should be a number',
+      });
+    }
+    const authEmail = emailDecrypt(req.header('authorization'));
+
+    const editableEntry = entries.find((entry) => entry.id === parseInt(entryId, 10));
+    if (!editableEntry) {
+      return res.status(404).send({
+        status: 404,
+        message: 'Non existing text entry',
+      });
+    }
+    if (editableEntry.userEmail !== authEmail) {
+      return res.status(403).send({
+        status: 403,
+        message: 'You are not authorized to take this action!',
+      });
+    }
+
+    editableEntry.title = title;
+    editableEntry.description = description;
+
+    return res.status(200).send({
+      status: 200,
+      message: 'Story was edited successfully',
+      data: editableEntry,
     });
   }
 }

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -11,6 +11,6 @@ const router = express.Router();
 router.post('/auth/signup', signUpSchema, Controller4user.signUp);
 router.post('/auth/signin', Controller4user.signIn);
 router.post('/entries', authanticate, createEntrySchema, Controller4entry.createEntry);
-
+router.patch('/entries/:entryId', authanticate, createEntrySchema, Controller4entry.editEntry);
 
 export default router;

--- a/server/tests/ytests4entry.js
+++ b/server/tests/ytests4entry.js
@@ -135,3 +135,91 @@ describe('POST entries ,/api/v1/entries', () => {
       });
   });
 });
+
+// Modify Entry
+describe(' 4. PATCH entries ,/api/v1/entries/:entryId', () => {
+  beforeEach((done) => {
+    chai.request(server).post('/api/v1/auth/signin').send({
+      email: 'emmanuel@gmail.com',
+      password: 'nkurunziza123',
+    }).then((res) => {
+      userToken = res.body.data.token;
+      done();
+    })
+      .catch((err) => console.log(err));
+  });
+  it('should return id is not number ', (done) => {
+    chai.request(server)
+      .patch('/api/v1/entries/wrt')
+      .set('authorization', userToken)
+      .set('Accept', 'application/json')
+      .send(entries[4])
+      .then((res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(400);
+        expect(res.body.status).to.equal(400);
+        done();
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  });
+  it('should return id is not found ', (done) => {
+    chai.request(server)
+      .patch('/api/v1/entries/10')
+      .set('authorization', userToken)
+      .set('Accept', 'application/json')
+      .send(entries[4])
+      .then((res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(404);
+        expect(res.body.status).to.equal(404);
+        done();
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  });
+  beforeEach((done) => {
+    chai.request(server).post('/api/v1/auth/signin').send({
+      email: 'emmanuel1@gmail.com',
+      password: 'nkurunziza12345',
+    }).then((res) => {
+      wrongToken = res.body.data.token;
+      done();
+    })
+      .catch((err) => console.log(err));
+  });
+  it('should return this entry does not belongs to you ', (done) => {
+    chai.request(server)
+      .patch('/api/v1/entries/1')
+      .set('authorization', wrongToken)
+      .set('Accept', 'application/json')
+      .send(entries[4])
+      .then((res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(403);
+        expect(res.body.status).to.equal(403);
+        done();
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  });
+  it('should return entry successfully edited', (done) => {
+    chai.request(server)
+      .patch('/api/v1/entries/1')
+      .set('authorization', userToken)
+      .set('Accept', 'application/json')
+      .send(entries[4])
+      .then((res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(200);
+        expect(res.body.status).to.equal(200);
+        done();
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
- with this feature, the user should be able to:
1.use the provided token,
2.have an authorization token allowing user to modify a diary entry title and description
 
#### Description of Task to be completed
- with this feature we put to place to the following functionalities to build the modify entry API:
1.make the editEntry method of the Controller4entry class
2.Building the route for modify entry API
3.writing the codes to test the modify entry

#### How should this be manually tested?
- clone the repo and switch to the branch ft-ch2-modify-entry-169378224
- start the server
- with this feature the following has been done to test the Modify Entry API functionalities:
1.run the test of the codes of modify entry
2.also testing the Modify entry API functionalities in POSTMAN

#### Any background context you want to provide?
- N/A

#### What are the relevant pivotal tracker stories?
[#169378224](https://www.pivotaltracker.com/story/show/169378224)

#### Screenshots (if appropriate)
Image of the modify entry API tested in POSTMAN
![image](https://user-images.githubusercontent.com/52543344/67613680-92c1f400-f7b0-11e9-879c-e63b9f28939c.png)
