### PR TITLE
[#169378709] ft(ch2-get-specific-entry): Get specific entry API

### DIFF
--- a/server/controllers/entryControllers.js
+++ b/server/controllers/entryControllers.js
@@ -65,9 +65,9 @@ class Controller4entry {
   //get all entries
   static getAllEntries = (req, res) => {
     const authEmail = emailDecrypt(req.header('authorization'));
-    entries.reverse(); // sorting in a descending order
+    entries.reverse(); 
     const userEntries = entries.filter((entry) => entry.userEmail
-      === authEmail); // filter for a lot of things
+      === authEmail); 
     if (userEntries.length === 0) {
       return res.status(404).send({
         status: 404,
@@ -78,6 +78,43 @@ class Controller4entry {
       status: 200,
       message: 'stories are successfully displayed',
       data: userEntries,
+    });
+  }
+
+  // get specific entry
+  static getSpecificEntry = (req, res) => {
+    const authEmail = emailDecrypt(req.header('authorization'));
+    let { entryId } = req.params;
+    const specificEntry = entries.find((entry) => entry.id
+      === parseInt(entryId, 10)); 
+    if (isNaN(entryId)) {
+      return res.status(400).send({
+        status: 400,
+        error: 'The entry id should be a number',
+      });
+    }
+    if (!entryId) {
+      return res.status(404).send({
+        status: 404,
+        error: 'Non existing text id!',
+      });
+    }
+    if (!specificEntry) {
+      return res.status(404).send({
+        status: 404,
+        message: 'Non existing text entry',
+      });
+    }
+    if (specificEntry.userEmail !== authEmail) {
+      return res.status(403).send({
+        status: 403,
+        message: 'You are not authorized to take this action!',
+      });
+    }
+    return res.status(200).send({
+      status: 200,
+      message: 'Story is displayed successfully',
+      data: specificEntry,
     });
   }
 }

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -13,5 +13,6 @@ router.post('/auth/signin', Controller4user.signIn);
 router.post('/entries', authanticate, createEntrySchema, Controller4entry.createEntry);
 router.patch('/entries/:entryId', authanticate, createEntrySchema, Controller4entry.editEntry);
 router.get('/entries', authanticate, Controller4entry.getAllEntries);
+router.get('/entries/:entryId', authanticate, Controller4entry.getSpecificEntry);
 
 export default router;

--- a/server/tests/ytests4entry.js
+++ b/server/tests/ytests4entry.js
@@ -271,3 +271,78 @@ describe('GET entries ,/api/v1/entries', () => {
       });
   });
 });
+
+// Get specific entry
+describe('GET entries ,/api/v1/entries/:entryId', () => {
+  beforeEach((done) => {
+    chai.request(server).post('/api/v1/auth/signin').send({
+      email: 'emmanuel@gmail.com',
+      password: 'nkurunziza123',
+    }).then((res) => {
+      userToken = res.body.data.token;
+      done();
+    })
+      .catch((err) => console.log(err));
+  });
+  it('should return: "id is not number"', (done) => {
+    chai.request(server)
+      .get('/api/v1/entries/wrt')
+      .set('authorization', userToken)
+      .set('Accept', 'application/json')
+      .then((res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(400);
+        expect(res.body.status).to.equal(400);
+        done();
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  });
+  it('should return: "not found id" ', (done) => {
+    chai.request(server)
+      .get('/api/v1/entries/10')
+      .set('authorization', userToken)
+      .set('Accept', 'application/json')
+      .then((res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(404);
+        expect(res.body.status).to.equal(404);
+        done();
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  });
+  it('should return:"this entry belongs to someone else"', (done) => {
+    chai.request(server)
+      .get('/api/v1/entries/1')
+      .set('authorization', wrongToken)
+      .set('Accept', 'application/json')
+      .then((res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(403);
+        expect(res.body.status).to.equal(403);
+        done();
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  });
+  it('should return: "Story is displayed successfully"', (done) => {
+    chai.request(server)
+      .get('/api/v1/entries/1')
+      .set('authorization', userToken)
+      .set('Accept', 'application/json')
+      .then((res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(200);
+        expect(res.body.status).to.equal(200);
+        expect(res.body.message).to.equal('Story is displayed successfully');
+        done();
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
- with this feature, the user should be able to:
1.use the provided token,
2.have an authorization token allowing user to get a specific diary entry title and description.


#### Description of Task to be completed
- For this feature we put to place the following functionalities to build the get all entries API:
1.create the getSpecificEntry method of the Controller4entry class
2.Building the route for getSpecificEntry entry API
3.writing the codes to test the get a specific entry


#### How should this be manually tested?
- clone the repo and switch to the branch ft-ch2-get-specific-entry-169378709
- start the server
- with this feature the following has been done to test the get specific entry API functionalities:
1.run the test of the codes up to get specific entry API
2.also testing the get specific entry API functionalities in POSTMAN


#### Any background context you want to provide?
- N/A

#### What are the relevant pivotal tracker stories?
[#169378709](https://www.pivotaltracker.com/story/show/169378709)

#### Screenshots (if appropriate)
Image of the get specific entry tested in POSTMAN
![image](https://user-images.githubusercontent.com/52543344/67615639-45a14a80-f7cf-11e9-9fdd-8a825e546093.png)
