### PR TITLE
[#169378864] ft(ch2-delete-entry): Delete an entry API

### DIFF
--- a/server/controllers/entryControllers.js
+++ b/server/controllers/entryControllers.js
@@ -117,6 +117,37 @@ class Controller4entry {
       data: specificEntry,
     });
   }
+
+  // delete entry
+  static deleteEntry = (req, res) => {
+    const authEmail = emailDecrypt(req.header('authorization'));
+    let { entryId } = req.params;
+    if (isNaN(entryId)) {
+      return res.status(400).send({
+        status: 400,
+        error: 'The entry id should be a number',
+      });
+    }
+    const entryToBeDeleted = entries.find((entry) => entry.id === parseInt(entryId, 10));
+    if (!entryToBeDeleted) {
+      return res.status(404).send({
+        status: 404,
+        message: 'Non existing text entry',
+      });
+    }
+
+    if (entryToBeDeleted.userEmail !== authEmail) {
+      return res.status(403).send({
+        status: 403,
+        error: 'You are not authorized to take this action!',
+      });
+    }
+    entries.splice(entries.indexOf(entryToBeDeleted), 1);
+    return res.status(200).send({
+      status: 200,
+      message: 'Story has been deleted successfully!',
+    });
+  }
 }
 
 export default Controller4entry;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -14,5 +14,6 @@ router.post('/entries', authanticate, createEntrySchema, Controller4entry.create
 router.patch('/entries/:entryId', authanticate, createEntrySchema, Controller4entry.editEntry);
 router.get('/entries', authanticate, Controller4entry.getAllEntries);
 router.get('/entries/:entryId', authanticate, Controller4entry.getSpecificEntry);
+router.delete('/entries/:entryId', authanticate, Controller4entry.deleteEntry);
 
 export default router;

--- a/server/tests/ytests4entry.js
+++ b/server/tests/ytests4entry.js
@@ -346,3 +346,91 @@ describe('GET entries ,/api/v1/entries/:entryId', () => {
       });
   });
 });
+
+// Delete Entry
+describe('DELETE entries ,/api/v1/entries/:entryId', () => {
+  beforeEach((done) => {
+    chai.request(server).post('/api/v1/auth/signin').send({
+      email: 'emmanuel@gmail.com',
+      password: 'nkurunziza123',
+    }).then((res) => {
+      userToken = res.body.data.token;
+      done();
+    })
+      .catch((err) => console.log(err));
+  });
+  it('should return: The entry id should be a number ', (done) => {
+    chai.request(server)
+      .delete('/api/v1/entries/id')
+      .set('authorization', userToken)
+      .set('Accept', 'application/json')
+      .then((res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(400);
+        expect(res.body.status).to.equal(400);
+        expect(res.body.error).to.equal('The entry id should be a number');
+        done();
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  });
+  it('should return: "Non existing text entry" ', (done) => {
+    chai.request(server)
+      .delete('/api/v1/entries/10')
+      .set('authorization', userToken)
+      .set('Accept', 'application/json')
+      .then((res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(404);
+        expect(res.body.status).to.equal(404);
+        expect(res.body.message).to.equal('Non existing text entry');
+        done();
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  });
+  beforeEach((done) => {
+    chai.request(server).post('/api/v1/auth/signin').send({
+      email: 'emmanuel1@gmail.com',
+      password: 'nkurunziza12345',
+    }).then((res) => {
+      wrongToken = res.body.data.token;
+      done();
+    })
+      .catch((err) => console.log(err));
+  });
+  it('should return: "You are not authorized to take this action!" ', (done) => {
+    chai.request(server)
+      .delete('/api/v1/entries/1')
+      .set('authorization', wrongToken)
+      .set('Accept', 'application/json')
+      .then((res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(403);
+        expect(res.body.status).to.equal(403);
+        expect(res.body.error).to.equal('You are not authorized to take this action!');
+        done();
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  });
+  it('should return: "Story has been deleted successfully!"', (done) => {
+    chai.request(server)
+      .delete('/api/v1/entries/1')
+      .set('authorization', userToken)
+      .set('Accept', 'application/json')
+      .then((res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(200);
+        expect(res.body.status).to.equal(200);
+        expect(res.body.message).to.equal('Story has been deleted successfully!');
+        done();
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
- with this feature, the user should be able to:
1.use the provided token,
2.have an authorization token allowing user to delete a specific diary entry title and description.


#### Description of Task to be completed
- For this feature we put to place the following functionalities to build the delete an entry API:
1.create the deleteEntry method of the Controller4entry class
2.Building the route for deleteEntry entry API
3.writing the codes to test the delete entry API codes


#### How should this be manually tested?
- clone the repo and switch to the branch ft-ch2-delete-entry-169378864
- start the server
-with this feature the following has been done to test the get specific entry API functionalities:
1.run the test of the codes which include also the codes of delete an entry API
2.also testing the delete entry API functionalities in POSTMAN


#### Any background context you want to provide?
- N/A


#### What are the relevant pivotal tracker stories?
[#169378864](https://www.pivotaltracker.com/story/show/169378864)


#### Screenshots (if appropriate)
Image of the delete entry API under test in POSTMAN
![image](https://user-images.githubusercontent.com/52543344/67617040-6ffb0400-f7df-11e9-8f1c-92ee4c0c7a11.png)
